### PR TITLE
Small window fix

### DIFF
--- a/src/nl/hanze/leertaak2/SimulatorView.java
+++ b/src/nl/hanze/leertaak2/SimulatorView.java
@@ -144,6 +144,8 @@ public class SimulatorView extends JFrame
      */
     private void makeFrame(){
     	setTitle("Fox and Rabbit Simulation");
+    	// Het programma laten afsluiten bij het klikken op het kruisje
+    	setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     	stepLabel = new JLabel(STEP_PREFIX, JLabel.CENTER);
     	population = new JLabel(POPULATION_PREFIX, JLabel.CENTER);
         setLocation(100, 50);    	


### PR DESCRIPTION
Fixed that the program wouldn't end when pressing the red cross in the top of the window.

![animated-gif-pringle-cat-picture-moving-to-a-beat](https://cloud.githubusercontent.com/assets/9349165/5764732/a03767c6-9cf4-11e4-829e-82c25d654be3.GIF)
